### PR TITLE
fix(api): align ImageRecord schema with frontend types

### DIFF
--- a/apps/api/routers/images.py
+++ b/apps/api/routers/images.py
@@ -7,7 +7,7 @@ import uuid
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from apps.api.core.config import get_settings
 from apps.api.core.security import get_current_user_id
@@ -35,11 +35,14 @@ _MAX_FILE_SIZE: int = 20 * 1024 * 1024  # 20 MB
 # Response schema
 # ------------------------------------------------------------------
 class ImageRecord(BaseModel):
-    id: str
+    model_config = {"populate_by_name": True}
+
+    image_id: str = Field(alias="id")
     user_id: str
     original_url: str
     protected_url: str | None = None
     watermark_id: str | None = None
+    c2pa_manifest: dict[str, Any] | None = None
     status: str
     created_at: str
     updated_at: str

--- a/apps/api/services/database.py
+++ b/apps/api/services/database.py
@@ -102,11 +102,21 @@ class DatabaseService:
         self,
         image_id: str,
         protected_url: str,
+        watermark_id: str | None = None,
+        c2pa_manifest: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Populate ``protected_url`` and mark the image as ``completed``."""
+        update_data: dict[str, Any] = {
+            "protected_url": protected_url,
+            "status": "completed",
+        }
+        if watermark_id is not None:
+            update_data["watermark_id"] = watermark_id
+        if c2pa_manifest is not None:
+            update_data["c2pa_manifest"] = c2pa_manifest
         response = (
             self._client.table(_TABLE_IMAGES)
-            .update({"protected_url": protected_url, "status": "completed"})
+            .update(update_data)
             .eq("id", image_id)
             .execute()
         )
@@ -141,6 +151,7 @@ class DebugDatabaseService(DatabaseService):
             "original_url": original_url,
             "protected_url": None,
             "watermark_id": watermark_id,
+            "c2pa_manifest": None,
             "status": "pending",
             "created_at": now,
             "updated_at": now,
@@ -176,6 +187,8 @@ class DebugDatabaseService(DatabaseService):
         self,
         image_id: str,
         protected_url: str,
+        watermark_id: str | None = None,
+        c2pa_manifest: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         row = self._store.get(image_id)
         if row is None:
@@ -183,6 +196,10 @@ class DebugDatabaseService(DatabaseService):
         row["protected_url"] = protected_url
         row["status"] = "completed"
         row["updated_at"] = datetime.now(timezone.utc).isoformat()
+        if watermark_id is not None:
+            row["watermark_id"] = watermark_id
+        if c2pa_manifest is not None:
+            row["c2pa_manifest"] = c2pa_manifest
         logger.info("[DEBUG] DB update: image_id=%s -> completed", image_id)
         return dict(row)
 

--- a/packages/shared-types/image.ts
+++ b/packages/shared-types/image.ts
@@ -1,11 +1,13 @@
 export type ImageStatus = "pending" | "processing" | "completed" | "failed";
 
 export interface ImageRecord {
-  id: string;
+  image_id: string;
   user_id: string;
   original_url: string;
   protected_url: string | null;
   watermark_id: string | null;
+  c2pa_manifest: Record<string, unknown> | null;
   status: ImageStatus;
   created_at: string;
+  updated_at: string;
 }


### PR DESCRIPTION
- Rename `id` to `image_id` using Pydantic field alias so API responses
  match what the frontend expects, fixing broken image list rendering
- Add missing `c2pa_manifest` field to API response schema
- Accept `watermark_id` and `c2pa_manifest` in `set_protected_url()` for
  both production and debug database services
- Sync shared-types package to match frontend/API contract

https://claude.ai/code/session_012ra8UBkgzSWfrQf8Xg4eCt