### PR TITLE
fix(api,worker): fix JWT verification, schema alias, and error_log co…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
 
+# --- JWT (Supabase project JWT secret — found in Project Settings > API) ---
+JWT_SECRET=your-supabase-jwt-secret-here
+
 # --- Cloudflare R2 ---
 R2_ACCESS_KEY_ID=
 R2_SECRET_ACCESS_KEY=

--- a/apps/api/core/config.py
+++ b/apps/api/core/config.py
@@ -23,6 +23,9 @@ class Settings(BaseSettings):
     SUPABASE_URL: str = ""
     SUPABASE_SERVICE_ROLE_KEY: str = ""
 
+    # --- JWT (Supabase project JWT secret for HS256 verification) ---
+    JWT_SECRET: str = ""
+
     # --- Cloudflare R2 (optional in DEBUG mode) ---
     R2_ACCESS_KEY_ID: str = ""
     R2_SECRET_ACCESS_KEY: str = ""

--- a/apps/api/core/security.py
+++ b/apps/api/core/security.py
@@ -47,7 +47,7 @@ def _decode_token(token: str, settings: Settings) -> dict[str, Any]:
     try:
         payload: dict[str, Any] = jwt.decode(
             token,
-            settings.SUPABASE_SERVICE_ROLE_KEY,
+            settings.JWT_SECRET,
             algorithms=[_ALGORITHM],
             audience=_AUDIENCE,
         )


### PR DESCRIPTION
…lumn issue

1. JWT: use JWT_SECRET instead of SUPABASE_SERVICE_ROLE_KEY for HS256 signature verification in security.py. Add JWT_SECRET to config and .env.example.

2. Schema: ImageRecord in schemas.py already uses Field(alias="id") with populate_by_name=True so DB rows with "id" are serialised as "image_id" — matching the frontend expectation.

3. Worker: remove error_log parameter from _update_image_status() since the images table has no error_log column. Error details are now stored only in tasks.error_log, preventing the images.status update from failing and leaving rows stuck in "processing".