### PR TITLE
fix: total_mem → total_memory + pin numpy<2 for torch 2.1.2

### DIFF
--- a/workers/gpu-worker/main.py
+++ b/workers/gpu-worker/main.py
@@ -278,7 +278,7 @@ def _log_gpu_info() -> None:
         logger.info("GPU count: %d", device_count)
         for i in range(device_count):
             name = torch.cuda.get_device_name(i)
-            mem = torch.cuda.get_device_properties(i).total_mem
+            mem = torch.cuda.get_device_properties(i).total_memory
             mem_gb = mem / (1024**3)
             logger.info("  GPU %d: %s (%.1f GB VRAM)", i, name, mem_gb)
         logger.info("Current device: %s", torch.cuda.current_device())

--- a/workers/gpu-worker/requirements.txt
+++ b/workers/gpu-worker/requirements.txt
@@ -10,7 +10,7 @@ torchvision==0.16.2+cu121
 # --- Image Processing ---
 Pillow>=10.0.0
 opencv-python-headless>=4.8.0
-numpy>=1.24.0
+numpy>=1.24.0,<2
 
 # --- Adversarial / Mist v2 ---
 diffusers>=0.25.0


### PR DESCRIPTION
- Fix AttributeError in _log_gpu_info(): PyTorch's CudaDeviceProperties uses 'total_memory', not 'total_mem' — this was the direct cause of the SaladCloud Instance Exited:1 crash
- Pin numpy>=1.24.0,<2 because torch 2.1.2 was compiled with NumPy 1.x and is incompatible with NumPy 2.x (causes _ARRAY_API not found warning and potential runtime crashes)

https://claude.ai/code/session_01CMhGnwot82KzbXxXUVqz7N