### PR TITLE
fix: use DROP/CREATE pattern for RLS policies in migrations

### DIFF
--- a/supabase/migrations/20250601_create_images_table.sql
+++ b/supabase/migrations/20250601_create_images_table.sql
@@ -23,21 +23,24 @@ ALTER TABLE public.images ENABLE ROW LEVEL SECURITY;
 
 -- 3. Policy: allow the service_role key to do everything (backend API)
 --    service_role automatically bypasses RLS, so this is a safety net.
-CREATE POLICY IF NOT EXISTS "service_role_full_access"
+DROP POLICY IF EXISTS "service_role_full_access" ON public.images;
+CREATE POLICY "service_role_full_access"
     ON public.images
     FOR ALL
     USING (true)
     WITH CHECK (true);
 
 -- 4. Policy: authenticated users can SELECT their own rows
-CREATE POLICY IF NOT EXISTS "users_select_own"
+DROP POLICY IF EXISTS "users_select_own" ON public.images;
+CREATE POLICY "users_select_own"
     ON public.images
     FOR SELECT
     TO authenticated
     USING (auth.uid() = user_id);
 
 -- 5. Policy: authenticated users can INSERT rows for themselves
-CREATE POLICY IF NOT EXISTS "users_insert_own"
+DROP POLICY IF EXISTS "users_insert_own" ON public.images;
+CREATE POLICY "users_insert_own"
     ON public.images
     FOR INSERT
     TO authenticated

--- a/supabase/migrations/20250602_create_tasks_table.sql
+++ b/supabase/migrations/20250602_create_tasks_table.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS public.tasks (
 -- RLS: authenticated users can SELECT tasks linked to their own images
 ALTER TABLE public.tasks ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Users can view own tasks" ON public.tasks;
 CREATE POLICY "Users can view own tasks"
     ON public.tasks
     FOR SELECT
@@ -25,6 +26,7 @@ CREATE POLICY "Users can view own tasks"
     );
 
 -- service_role bypasses RLS automatically, but add explicit policy for clarity
+DROP POLICY IF EXISTS "service_role_full_access" ON public.tasks;
 CREATE POLICY "service_role_full_access"
     ON public.tasks
     FOR ALL


### PR DESCRIPTION
PostgreSQL CREATE POLICY does not support IF NOT EXISTS syntax. Changed to DROP POLICY IF EXISTS + CREATE POLICY for idempotent execution.

https://claude.ai/code/session_01CMhGnwot82KzbXxXUVqz7N