### PR TITLE
fix(api): use validation_alias to serialize ImageRecord.image_id correctly

### DIFF
--- a/apps/api/models/schemas.py
+++ b/apps/api/models/schemas.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, Field
 class ImageRecord(BaseModel):
     model_config = {"populate_by_name": True}
 
-    image_id: str = Field(alias="id")
+    image_id: str = Field(validation_alias="id")
     user_id: str
     original_url: str
     protected_url: str | None = None

--- a/apps/api/tests/test_integration.py
+++ b/apps/api/tests/test_integration.py
@@ -83,7 +83,7 @@ def test_get_image_after_upload_returns_pending(integration_client):
     assert get_resp.status_code == 200, f"Expected 200, got {get_resp.status_code}: {get_resp.text}"
     data = get_resp.json()
     assert data["status"] == "pending", f"Expected status 'pending', got '{data['status']}'"
-    assert data["id"] == image_id
+    assert data["image_id"] == image_id
 
 
 # ---------------------------------------------------------------------------
@@ -103,5 +103,5 @@ def test_list_images_contains_uploaded_image(integration_client):
     list_resp = integration_client.get("/api/v1/images/")
     assert list_resp.status_code == 200, f"Expected 200, got {list_resp.status_code}: {list_resp.text}"
     data = list_resp.json()
-    image_ids = [img["id"] for img in data["images"]]
+    image_ids = [img["image_id"] for img in data["images"]]
     assert image_id in image_ids, f"image_id {image_id} not found in image list: {image_ids}"


### PR DESCRIPTION
## 問題

FastAPI はデフォルトで `by_alias=True` でレスポンスをシリアライズする。

`Field(alias="id")` を使っていたため、JSON レスポンスのキーは `"id"` になっていたが、フロントエンドの TypeScript 型 `ImageRecord` は `"image_id"` を期待している。

これにより、画像一覧・画像詳細ページで `image_id` が `undefined` になっていた（削除ボタン・ダウンロードリンクが動作しない）。

## 修正内容

`Field(alias="id")` → `Field(validation_alias="id")` に変更。

- **バリデーション**: DB から返される `"id"` キーは引き続き受け付ける
- **シリアライズ**: alias なしのフィールド名 `image_id` で出力 → フロントエンドと一致

## テスト

```
apps/api/tests/test_health.py::test_health_returns_200 PASSED
apps/api/tests/test_integration.py::test_upload_image_returns_201_with_image_id PASSED
apps/api/tests/test_integration.py::test_get_image_after_upload_returns_pending PASSED
apps/api/tests/test_integration.py::test_list_images_contains_uploaded_image PASSED
apps/api/tests/test_upload.py::test_upload_no_file_returns_422 PASSED
apps/api/tests/test_upload.py::test_upload_unsupported_type_returns_415 PASSED
apps/api/tests/test_upload.py::test_upload_oversized_file_returns_413 PASSED
7 passed, 0 failed
```

## 関連

Closes #11 (PR #11 は同じ問題を修正しようとしていたが、main のコードを大量にリグレッションさせる形になっていたためクローズ済み)