### PR TITLE
fix(tests): update e2e_local_test.py to use image_id key

### DIFF
--- a/tests/e2e_local_test.py
+++ b/tests/e2e_local_test.py
@@ -65,7 +65,7 @@ def main() -> None:
     resp = requests.get(f"{BASE_URL}/api/v1/images/", timeout=5)
     assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
     data = resp.json()
-    image_ids = [img["id"] for img in data["images"]]
+    image_ids = [img["image_id"] for img in data["images"]]
     assert image_id in image_ids, f"image_id {image_id} not found in list: {image_ids}"
     print("OK")
     passed += 1


### PR DESCRIPTION
PR #16 のスキーマ修正後、API レスポンスのキーが `"id"` から `"image_id"` に変わった。
`tests/e2e_local_test.py` の Step d がまだ `img["id"]` を参照していたため修正。

Related: #16